### PR TITLE
Added support for Tensor Network simulation and minor improvements

### DIFF
--- a/lazyqml/Factories/Dispatchers/Dispatcher.py
+++ b/lazyqml/Factories/Dispatchers/Dispatcher.py
@@ -125,9 +125,7 @@ class Dispatcher:
 
                         # Filtramos los resultados None (errores) y los añadimos a results
                         # valid_results = [r for r in batch_results if r is not None]
-                        print("01")
                         results.extend(batch_results)
-                        print("02")
 
                     # Liberar recursos después del procesamiento
                     with resource_lock:

--- a/lazyqml/Factories/Dispatchers/Dispatcher.py
+++ b/lazyqml/Factories/Dispatchers/Dispatcher.py
@@ -11,8 +11,7 @@ import torch
 from lazyqml.Utils.Utils import *
 from lazyqml.Factories.Models.fModels import *
 from lazyqml.Factories.Preprocessing.fPreprocessing import *
-from lazyqml.Utils.Utils import printer
-import lazyqml
+from lazyqml.Utils import get_simulation_type, printer
     # External Libraries
 from sklearn.metrics import f1_score, accuracy_score, balanced_accuracy_score
 from multiprocessing import Queue, Process, Pool, Manager
@@ -167,7 +166,7 @@ class Dispatcher:
         cpu_items = []
         gpu_items = []
 
-        tensor_sim = lazyqml.get_simulation_type() == "tensor"
+        tensor_sim = get_simulation_type() == "tensor"
 
         RAM = calculate_free_memory()
         VRAM = calculate_free_video_memory()
@@ -262,7 +261,7 @@ class Dispatcher:
             }
 
             # When adding items to queues
-            if name == Model.QNN and qubits >= self.threshold and VRAM > calculate_quantum_memory(qubits, lazyqml._max_bond_dim):
+            if name == Model.QNN and qubits >= self.threshold and VRAM > calculate_quantum_memory(qubits):
                 model_factory_params["backend"] = Backend.lightningGPU if not tensor_sim else Backend.lightningTensor
                 gpu_queue.put((combination,(model_factory_params, X_train_processed, y_train_processed, X_test_processed, y_test_processed, predictions, customMetric)))
                 gpu_items.append(combination)

--- a/lazyqml/Factories/Models/QNNTorch.py
+++ b/lazyqml/Factories/Models/QNNTorch.py
@@ -7,8 +7,7 @@ from lazyqml.Interfaces.iAnsatz import Ansatz
 from lazyqml.Interfaces.iCircuit import Circuit
 from lazyqml.Factories.Circuits.fCircuits import *
 from lazyqml.Global.globalEnums import Backend
-from lazyqml.Utils.Utils import printer
-import lazyqml
+from lazyqml.Utils import printer, get_simulation_type, get_max_bond_dim
 
 import warnings
 
@@ -26,16 +25,16 @@ class QNNTorch(Model):
         self.batch_size = batch_size
         self.backend = backend
 
-        if lazyqml.get_simulation_type() == "tensor":
+        if get_simulation_type() == "tensor":
             if backend != Backend.lightningTensor:
                 device_kwargs = {
-                    "max_bond_dim": lazyqml._max_bond_dim,
+                    "max_bond_dim": get_max_bond_dim(),
                     "cutoff": np.finfo(np.complex128).eps,
                     "contract": "auto-mps",
                 }
             else:
                 device_kwargs = {
-                    "max_bond_dim": lazyqml._max_bond_dim,
+                    "max_bond_dim": get_max_bond_dim(),
                     "cutoff": 1e-10,
                     "cutoff_mode": "abs",
                 }
@@ -71,7 +70,7 @@ class QNNTorch(Model):
         
 
         # Define the quantum circuit as a PennyLane qnode
-        @qml.qnode(self.deviceQ, interface='torch', diff_method='adjoint' if lazyqml.get_simulation_type() == "statevector" else 'best')
+        @qml.qnode(self.deviceQ, interface='torch', diff_method='adjoint' if get_simulation_type() == "statevector" else 'best')
         def circuit(x, theta):
             
             embedding.getCircuit()(x, wires=range(self.nqubits))

--- a/lazyqml/Factories/Models/QSVM.py
+++ b/lazyqml/Factories/Models/QSVM.py
@@ -1,11 +1,7 @@
 from lazyqml.Interfaces.iModel import Model
 import numpy as np
 from sklearn.svm import SVC
-from sklearn.preprocessing import StandardScaler
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, balanced_accuracy_score
 import pennylane as qml
-from time import time
 from lazyqml.Factories.Circuits.fCircuits import CircuitFactory
 from lazyqml.Utils.Utils import printer
 
@@ -38,16 +34,8 @@ class QSVM(Model):
     # Not used at the moment, We might be interested in computing our own kernel.
     def _quantum_kernel(self, X1, X2):
         """Calculate the quantum kernel matrix for SVM."""
-        num_samples_1 = len(X1)
-        num_samples_2 = len(X2)
-        kernel_matrix = np.zeros((num_samples_1, num_samples_2))
 
-        for i in range(num_samples_1):
-            for j in range(num_samples_2):
-                kernel_matrix[i, j] = self.kernel_circ(X1[i], X2[j]).sum()
-
-        #return kernel_matrix
-        return np.array([[self.kernel_circ(x1 , x2)[0] for x2 in X2]for x1 in X1])
+        return np.array([[self.kernel_circ(x1, x2)[0] for x2 in X2]for x1 in X1])
 
     def fit(self, X, y):
         self.X_train = X

--- a/lazyqml/Global/globalEnums.py
+++ b/lazyqml/Global/globalEnums.py
@@ -37,5 +37,9 @@ class Model(BaseEnum):
 
 class Backend(Enum):
     defaultQubit = "default.qubit"
+    
     lightningQubit = "lightning.qubit"
     lightningGPU = "lightning.gpu"
+
+    defaultTensor = "default.tensor"
+    lightningTensor = "lightning.tensor"

--- a/lazyqml/Interfaces/__init__.py
+++ b/lazyqml/Interfaces/__init__.py
@@ -1,0 +1,1 @@
+from .iCircuit import Circuit

--- a/lazyqml/Utils/Utils.py
+++ b/lazyqml/Utils/Utils.py
@@ -75,7 +75,10 @@ def calculate_quantum_memory(num_qubits, overhead=2):
     bytes_per_qubit_state = 16
 
     # Number of possible states is 2^n, where n is the number of qubits
-    num_states = 2 ** num_qubits
+    if get_simulation_type() == "statevector":
+        num_states = 2 ** num_qubits
+    else:
+        num_states =  num_qubits * (get_max_bond_dim() ** 2)
 
     # Total memory in bytes
     total_memory_bytes = num_states * bytes_per_qubit_state * overhead

--- a/lazyqml/Utils/Utils.py
+++ b/lazyqml/Utils/Utils.py
@@ -9,6 +9,7 @@ import GPUtil
 from sklearn.model_selection import LeaveOneOut, StratifiedKFold, train_test_split
 from lazyqml.Global.globalEnums import *
 from itertools import product
+import lazyqml._config as config
 
 """
 ------------------------------------------------------------------------------------------------------------------
@@ -291,5 +292,25 @@ def dataProcessing(X, y, prepFactory, customImputerCat, customImputerNum,
     y_test = np.array(y_test)
 
     return X_train_processed, X_test_processed, y_train, y_test
+
+######
+def set_max_bond_dim(dim: int):
+    config._max_bond_dim = dim
+
+def get_max_bond_dim():
+    return config._max_bond_dim
+
+def set_simulation_type(sim):
+    try:
+        assert sim == "statevector" or sim == "tensor"
+        config._simulation = sim
+
+    except Exception as e:
+        raise ValueError(f"Simulation type must be \"statevector\" or \"tensor\". Got \"{sim}\"")
+    
+
+def get_simulation_type():
+    return config._simulation
+######
 
 printer = VerbosePrinter()

--- a/lazyqml/Utils/__init__.py
+++ b/lazyqml/Utils/__init__.py
@@ -1,0 +1,2 @@
+from .Utils import get_max_bond_dim, get_simulation_type, set_max_bond_dim, set_simulation_type
+from .Utils import printer

--- a/lazyqml/__init__.py
+++ b/lazyqml/__init__.py
@@ -11,7 +11,6 @@ _simulation = "statevector"
 def set_simulation_type(sim):
     try:
         assert sim == "statevector" or sim == "tensor"
-
         lazyqml._simulation = sim
 
     except Exception as e:
@@ -20,3 +19,12 @@ def set_simulation_type(sim):
 
 def get_simulation_type():
     return lazyqml._simulation
+
+# Max bond dimension getter/setter
+_max_bond_dim = 64
+
+def set_max_bond_dim(dim: int):
+    lazyqml._max_bond_dim = dim
+
+def get_max_bond_dim():
+    return lazyqml._max_bond_dim

--- a/lazyqml/__init__.py
+++ b/lazyqml/__init__.py
@@ -4,27 +4,4 @@ __author__ = """Diego García Vega, Fernando Álvaro Plou Llorente, Alejandro Le
 __email__ = "garciavdiego@uniovi.es, ploufernando@uniovi.es, lealcalejandro@uniovi.es"
 __version__ = "0.0.8"
 
-import lazyqml
-
-_simulation = "statevector"
-
-def set_simulation_type(sim):
-    try:
-        assert sim == "statevector" or sim == "tensor"
-        lazyqml._simulation = sim
-
-    except Exception as e:
-        raise ValueError(f"Simulation type must be \"statevector\" or \"tensor\". Got \"{sim}\"")
-    
-
-def get_simulation_type():
-    return lazyqml._simulation
-
-# Max bond dimension getter/setter
-_max_bond_dim = 64
-
-def set_max_bond_dim(dim: int):
-    lazyqml._max_bond_dim = dim
-
-def get_max_bond_dim():
-    return lazyqml._max_bond_dim
+from .lazyqml import QuantumClassifier

--- a/lazyqml/__init__.py
+++ b/lazyqml/__init__.py
@@ -3,3 +3,20 @@
 __author__ = """Diego García Vega, Fernando Álvaro Plou Llorente, Alejandro Leal Castaño"""
 __email__ = "garciavdiego@uniovi.es, ploufernando@uniovi.es, lealcalejandro@uniovi.es"
 __version__ = "0.0.8"
+
+import lazyqml
+
+_simulation = "statevector"
+
+def set_simulation_type(sim):
+    try:
+        assert sim == "statevector" or sim == "tensor"
+
+        lazyqml._simulation = sim
+
+    except Exception as e:
+        raise ValueError(f"Simulation type must be \"statevector\" or \"tensor\". Got \"{sim}\"")
+    
+
+def get_simulation_type():
+    return lazyqml._simulation

--- a/lazyqml/_config.py
+++ b/lazyqml/_config.py
@@ -1,0 +1,2 @@
+_simulation = "statevector"
+_max_bond_dim = 64

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ psutil
 pandas
 joblib
 gputil
+quimb

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -68,6 +68,7 @@ scikit-learn
 PennyLane==0.39
 PennyLane_Lightning==0.39
 PennyLane_Lightning_GPU==0.39
+quimb
 custatevec_cu12
 ucimlrepo
 pydantic

--- a/tests/test_lazyqml.py
+++ b/tests/test_lazyqml.py
@@ -2,17 +2,35 @@
 
 """Tests for `lazyqml` package."""
 
-
 import unittest
-
-
 
 class TestLazyqml(unittest.TestCase):
     """Tests for `lazyqml` package."""
 
     def test_import(self):
         import lazyqml 
-        print("Imported correctly")
-        
+        # print("Imported correctly")
 
-    
+    def test_simulation_strings(self):
+        # Verify getter/setter of simulation type flag
+        from lazyqml import lazyqml
+
+        sim = "statevector"
+        lazyqml.set_simulation_type(sim)
+        self.assertTrue(lazyqml.get_simulation_type(), "statevector")
+
+        sim = "tensor"
+        lazyqml.set_simulation_type(sim)
+        self.assertTrue(lazyqml.get_simulation_type(), "tensor")
+
+        # Verify that ValueError is raised when number or different string is set
+        sim = 3
+        with self.assertRaises(ValueError):
+            lazyqml.set_simulation_type(sim)
+
+        sim = "tns"
+        with self.assertRaises(ValueError):
+            lazyqml.set_simulation_type(sim)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lazyqml.py
+++ b/tests/test_lazyqml.py
@@ -4,6 +4,15 @@
 
 import unittest
 
+def import_data():
+    from sklearn.datasets import load_iris
+
+    # Load data
+    data = load_iris()
+    X = data.data
+    y = data.target
+    return X, y
+
 class TestLazyqml(unittest.TestCase):
     """Tests for `lazyqml` package."""
 
@@ -13,7 +22,7 @@ class TestLazyqml(unittest.TestCase):
 
     def test_simulation_strings(self):
         # Verify getter/setter of simulation type flag
-        from lazyqml import lazyqml
+        import lazyqml
 
         sim = "statevector"
         lazyqml.set_simulation_type(sim)
@@ -31,6 +40,60 @@ class TestLazyqml(unittest.TestCase):
         sim = "tns"
         with self.assertRaises(ValueError):
             lazyqml.set_simulation_type(sim)
+
+    def test_bdim(self):
+        import lazyqml
+
+        # TODO: Desarrollar mas
+        lazyqml.get_max_bond_dim()
+
+    def test_basic_exec(self):
+        from lazyqml.lazyqml import QuantumClassifier
+        from lazyqml.Global.globalEnums import Embedding, Ansatzs, Model
+
+        X, y = import_data()
+
+        qubits = 4
+        nqubits = {qubits}
+        embeddings = {Embedding.RX}
+        ansatzs = {Ansatzs.TWO_LOCAL}
+        models = {Model.QSVM}
+        layers = 2
+        verbose = False
+        sequential = False
+
+        qc = QuantumClassifier(nqubits=nqubits, embeddings=embeddings, ansatzs=ansatzs, classifiers=models, numLayers=layers,
+                            verbose=verbose, sequential=sequential)
+        
+        # if cores > 1: qc.repeated_cross_validation(X,y,n_splits=splits,n_repeats=repeats)
+        # else: qc.fit(X, y)
+        qc.fit(X, y)
+
+    def test_tensor(self):
+        from lazyqml.lazyqml import QuantumClassifier
+        from lazyqml.Global.globalEnums import Embedding, Ansatzs, Model, Backend
+        import lazyqml
+
+        lazyqml.set_simulation_type("tensor")
+        assert lazyqml.get_simulation_type() == "tensor"
+
+        X, y = import_data()
+
+        qubits = 4
+        nqubits = {qubits}
+        embeddings = {Embedding.RX}
+        ansatzs = {Ansatzs.TWO_LOCAL}
+        models = {Model.QNN}
+        epochs = 2
+        layers = 2
+        verbose = True
+        sequential = False
+        backend = Backend.lightningTensor
+
+        qc = QuantumClassifier(nqubits=nqubits, embeddings=embeddings, ansatzs=ansatzs, classifiers=models, numLayers=layers, epochs=epochs,
+                            verbose=verbose, sequential=sequential, backend=backend)
+        
+        qc.fit(X, y)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lazyqml.py
+++ b/tests/test_lazyqml.py
@@ -16,39 +16,43 @@ def import_data():
 class TestLazyqml(unittest.TestCase):
     """Tests for `lazyqml` package."""
 
+    @classmethod
+    def setUpClass(self):
+        from lazyqml.Utils import get_simulation_type, get_max_bond_dim, set_simulation_type
+
     def test_import(self):
         import lazyqml 
         # print("Imported correctly")
 
     def test_simulation_strings(self):
-        # Verify getter/setter of simulation type flag
-        import lazyqml
+        from lazyqml.Utils import get_simulation_type, get_max_bond_dim, set_simulation_type
 
+        # Verify getter/setter of simulation type flag
         sim = "statevector"
-        lazyqml.set_simulation_type(sim)
-        self.assertTrue(lazyqml.get_simulation_type(), "statevector")
+        set_simulation_type(sim)
+        self.assertTrue(get_simulation_type(), "statevector")
 
         sim = "tensor"
-        lazyqml.set_simulation_type(sim)
-        self.assertTrue(lazyqml.get_simulation_type(), "tensor")
+        set_simulation_type(sim)
+        self.assertTrue(get_simulation_type(), "tensor")
 
         # Verify that ValueError is raised when number or different string is set
         sim = 3
         with self.assertRaises(ValueError):
-            lazyqml.set_simulation_type(sim)
+            set_simulation_type(sim)
 
         sim = "tns"
         with self.assertRaises(ValueError):
-            lazyqml.set_simulation_type(sim)
+            set_simulation_type(sim)
 
-    def test_bdim(self):
+    def _test_bdim(self):
         import lazyqml
 
         # TODO: Desarrollar mas
         lazyqml.get_max_bond_dim()
 
-    def test_basic_exec(self):
-        from lazyqml.lazyqml import QuantumClassifier
+    def _test_basic_exec(self):
+        from lazyqml import QuantumClassifier
         from lazyqml.Global.globalEnums import Embedding, Ansatzs, Model
 
         X, y = import_data()
@@ -70,12 +74,12 @@ class TestLazyqml(unittest.TestCase):
         qc.fit(X, y)
 
     def test_tensor(self):
-        from lazyqml.lazyqml import QuantumClassifier
+        from lazyqml import QuantumClassifier
         from lazyqml.Global.globalEnums import Embedding, Ansatzs, Model, Backend
-        import lazyqml
+        from lazyqml.Utils import get_simulation_type, get_max_bond_dim, set_simulation_type
 
-        lazyqml.set_simulation_type("tensor")
-        assert lazyqml.get_simulation_type() == "tensor"
+        set_simulation_type("tensor")
+        assert get_simulation_type() == "tensor"
 
         X, y = import_data()
 
@@ -90,8 +94,7 @@ class TestLazyqml(unittest.TestCase):
         sequential = False
         backend = Backend.lightningTensor
 
-        qc = QuantumClassifier(nqubits=nqubits, embeddings=embeddings, ansatzs=ansatzs, classifiers=models, numLayers=layers, epochs=epochs,
-                            verbose=verbose, sequential=sequential, backend=backend)
+        qc = QuantumClassifier(nqubits=nqubits, embeddings=embeddings, ansatzs=ansatzs, classifiers=models, numLayers=layers, epochs=epochs, verbose=verbose, sequential=sequential, backend=backend)
         
         qc.fit(X, y)
 


### PR DESCRIPTION
### Main features
Added Tensor Network simulation for QNN models:
- Module variables ``_simulation`` and ``_max_bond_dim`` to set simulation type. Possible values are ``statevector`` for state vector representation of the qubits and ``tensor`` for tensor network (MPS) representation.
- Functions  ``set_max_bond_dim``, ``get_max_bond_dim``, ``set_simulation_type`` and ``get_simulation_type`` to change simulation type and behaviour of the library.
- Added unit tests in ``tests/`` to ensure the correct operation of this feature.

```python
# sim_var_example.py
import lazyqml

# This changes qubit representation to tensor networks (mps)
lazyqml.Utils.set_simulation_type("tensor")
lazyqml.Utils.set_max_bond_dim(32)

# rest of the QuantumClassifier workflow
```

#### Minor changes
- Deleted redundant code when building the kernel for QSVM, cutting execution times for this model roughly in half.
- Included multiple imports in \_\_init\_\_.py files to improve usability, readability and relative imports within the module. ![Reference](https://docs.python.org/3/tutorial/modules.html#packages).
	- For example, this simplifies ``QuantumClassifier`` class import:
```python
# old
from lazyqml.lazyqml import QuantumClassifier

# new
from lazyqml import QuantumClassifier
```